### PR TITLE
Add prepare_action to prepare the MCU before the flash

### DIFF
--- a/mcus.ini
+++ b/mcus.ini
@@ -15,7 +15,8 @@ flash_command: ./scripts/flash-sdcard.sh /dev/ttyAMA0 btt-octopus-f446-v1
 
 # If your Octopus is used as a USB CAn Bridge with Katapult/Canboot
 #[octopus]
-#preflash_command: python3 ~/katapult/scripts/flash_can.py -i can0 -r -u 579164a7c2ba ; sleep 2
+#prepare_command: python3 ~/katapult/scripts/flash_can.py -i can0 -r -u 579164a7c2ba
+#prepare_command: sleep 2
 #flash_command: python3 ~/katapult/scripts/flash_can.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_2D0012001750344D30353320-if00
 
 [nevermore]

--- a/mcus.ini
+++ b/mcus.ini
@@ -13,6 +13,11 @@ flash_command: make flash
 [octopus]
 flash_command: ./scripts/flash-sdcard.sh /dev/ttyAMA0 btt-octopus-f446-v1
 
+# If your Octopus is used as a USB CAn Bridge with Katapult/Canboot
+#[octopus]
+#preflash_command: python3 ~/katapult/scripts/flash_can.py -i can0 -r -u 579164a7c2ba ; sleep 2
+#flash_command: python3 ~/katapult/scripts/flash_can.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_2D0012001750344D30353320-if00
+
 [nevermore]
 flash_command: make flash FLASH_DEVICE=/dev/serial/by-id/usb-Klipper_rp2040_<your_id_here>-if00
 

--- a/update_klipper.sh
+++ b/update_klipper.sh
@@ -117,7 +117,7 @@ update_mcus () {
 	          # Split the prepare command string into separate commands and run each one
             IFS=";" read -ra commands <<< "${prepare_actions[$mcu]}"
             for command in "${commands[@]}"; do
-                echo "Command: $command"
+                echo "Prepare Command: $command"
 
                 if $QUIET ; then
                     eval "$command" &> /dev/null
@@ -134,7 +134,7 @@ update_mcus () {
                     # Add KCONFIG_CONFIG=config/$mcu after "make flash"
                     command="${command/make\ flash/make\ flash\ $config_file_str}"
                 fi
-                echo "Command: $command"
+                echo "Flash Command: $command"
                 eval "$command"
             done
         fi


### PR DESCRIPTION
Also added an example in `mcus.ini`. Mainly used for Octopus USB to CAN bridge setup with Katapult/CANBoot