### PR TITLE
Adding 2 small python scripts to be able to invoke bootloader on serial and serial usb-port

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,38 @@ action_command : make flash FLASH_DEVICE=/dev/serial/by-id/usb-Klipper_rp2040_<B
 ```
 _source: Cannot remember_
 
+```
+[spider]
+# spider on serial port (rpi gpio)
+action_command: ~/update_klipper_and_mcus/bootloader_serial.py /dev/ttyAMA0 250000
+action_command: ~/katapult/scripts/flashtool.py -d /dev/ttyAMA0 -b 250000
+```
+_source : [Klipper doc](https://www.klipper3d.org/RPi_microcontroller.html#building-the-micro-controller-code)_
+
+```
+[spider]
+# spider on serial port (rpi gpio) at 250000bps
+action_command: ~/update_klipper_and_mcus/bootloader_serial.py /dev/ttyAMA0 250000
+action_command: ~/katapult/scripts/flashtool.py -d /dev/ttyAMA0 -b 250000
+```
+_source : [Klipper doc](https://www.klipper3d.org/Bootloader_Entry.html#physical-serial)_
+
+```
+[catalyst]
+# catalyst on usb-serial port (using bootloader_usb.py)
+action_command: ~/update_klipper_and_mcus/bootloader_usb.py /dev/serial/by-id/usb-Klipper_stm32f401xc_<board_serial>
+quiet_command: sleep 1
+action_command: ~/katapult/scripts/flashtool.py -d /dev/serial/by-id/usb-katapult_stm32f401xc_<board_serial> -b 250000
+```
+_source : [Klipper doc](https://www.klipper3d.org/Bootloader_Entry.html#python-with-flash_usb)_
+
+```
+[catalyst]
+# catalyst on usb-serial port (using make flash)
+action_command: make flash FLASH_DEVICE=/dev/serial/by-id/usb-Klipper_stm32f401xc_<board_serial>
+```
+_source : [Klipper doc](https://www.klipper3d.org/RPi_microcontroller.html#building-the-micro-controller-code)_
+
 ## Usage
 
 Run ``~/<script_folder>/update_klipper.sh`` in a terminal, you can use the following options.

--- a/bootloader_serial.py
+++ b/bootloader_serial.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+#
+# Tool to request the bootloader on MCU connected via UART port (not for usb-serial)
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import sys, serial
+
+ser = serial.Serial(sys.argv[1], int(sys.argv[2]), timeout=1)
+# see https://www.klipper3d.org/Bootloader_Entry.html#physical-serial
+ser.write(str.encode("~ \x1c Request Serial Bootloader!! ~"))

--- a/bootloader_usb.py
+++ b/bootloader_usb.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# 
+# Tool to request the bootloader on MCU connected via usb-serial port
+#
+# see https://www.klipper3d.org/Bootloader_Entry.html#python-with-flash_usb
+# 
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import sys
+# use klipper flash_usb module
+from pathlib import Path
+sys.path.append(str(Path.home()) + "/klipper/scripts") 
+import flash_usb as u
+
+u.enter_bootloader(sys.argv[1])


### PR DESCRIPTION
Hello,

A small PR to add 2 scripts :
* bootloader_serial.py
* bootloader_usb.py

They are used to ask klipper firmware to invoke the bootloader, see :
* https://www.klipper3d.org/Bootloader_Entry.html#python-with-flash_usb
* https://www.klipper3d.org/Bootloader_Entry.html#physical-serial

I've also added some exemple to the Readme.
