### PR TITLE
Fix : config folder creation / klipper stop

### DIFF
--- a/scripts/mcus.sh
+++ b/scripts/mcus.sh
@@ -97,7 +97,7 @@ function update_mcus() {
     if ! prompt "Update firmware of ${WHITE}$mcu_str${MAGENTA} ?" $def; then
       continue
     fi
-    klipperservice stop
+
     # Check if the config folder exists
     if [ ! -d "$ukam_config/config" ]; then
       # If it doesn't exist, create it
@@ -118,9 +118,10 @@ function update_mcus() {
       TMP_MENUCONFIG=true
     fi
 
+    # Stop klipper before build firmware
+    klipperservice stop
     # Change to the Klipper directory
     cd ~/klipper
-
     # Clean the previous build and configure for the selected MCU
     make clean $config_file_str
     # Open menuconfig if needed

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -130,8 +130,10 @@ except serial.SerialException as e:
 function link_config {
   if [ ! -d $ukam_config ]; then
     mkdir $ukam_config
-    echo -e "\n${DEFAULT}New config folder ${ukam_config}"
-    ln -s $ukam_path/config $ukam_config/config
+    echo -e "\n${DEFAULT}Create new config folder ${ukam_config}"
+    if [ -d $ukam_path/config ]; then
+      ln -s $ukam_path/config $ukam_config/config
+    fi
     if [ -e $ukam_path/mcus.ini ]; then
       echo -e "${DEFAULT}Moving mcus.ini to ${ukam_config}\n"
       mv $ukam_path/mcus.ini $ukam_config


### PR DESCRIPTION
https://github.com/fbeauKmi/update_klipper_and_mcus/commit/7ece0025db4c4de737743abaccbd9e066aee8994 to solve the second issue in #6 . Avoid to create an invalid link to config at first run if config doesn't exist.

https://github.com/fbeauKmi/update_klipper_and_mcus/commit/8272cbc95903194c8bd8ae6a59c1bc63b3a3bbc6
Stop klipper, if needed, only after all checks done.