### PR TITLE
Fix: Fail to save version if config not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 README.md
 mcus.ini
 !examples/mcus.ini
+config
 config/*
-!config/.placeholder

--- a/scripts/mcus.sh
+++ b/scripts/mcus.sh
@@ -98,13 +98,6 @@ function update_mcus() {
       continue
     fi
 
-    # Check if the config folder exists
-    if [ ! -d "$ukam_config/config" ]; then
-      # If it doesn't exist, create it
-      mkdir -p "$ukam_config/config"
-      echo "Config folder created at: $ukam_config/config"
-    fi
-
     # Initiate menuconfig check for current mcu
     TMP_MENUCONFIG=$MENUCONFIG
     # Set config_file in the scripts directory

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -130,7 +130,8 @@ except serial.SerialException as e:
 function link_config {
   if [ ! -d $ukam_config ]; then
     mkdir $ukam_config
-    echo -e "\n${DEFAULT}Create new config folder ${ukam_config}"
+    echo -e "\n${DEFAULT}Create folder ${ukam_config}"
+    #link existing folder (compatibity with previous version)
     if [ -d $ukam_path/config ]; then
       ln -s $ukam_path/config $ukam_config/config
     fi
@@ -138,8 +139,13 @@ function link_config {
       echo -e "${DEFAULT}Moving mcus.ini to ${ukam_config}\n"
       mv $ukam_path/mcus.ini $ukam_config
     else
-      echo -e "${DEFAULT}Copying  sample mcus.ini to ${ukam_config}\n"
+      echo -e "${DEFAULT}Copying sample mcus.ini to ${ukam_config}\n"
       cp $ukam_path/examples/mcus.ini $ukam_config
     fi
+  fi
+  if [ ! -d "$ukam_config/config" ]; then
+      # If it doesn't exist, create it
+      mkdir -p "$ukam_config/config"
+      echo -e "${DEFAULT}Create folder $ukam_config/config\n"
   fi
 }


### PR DESCRIPTION
As shown here https://github.com/fbeauKmi/update_klipper_and_mcus/issues/6#issuecomment-2451769144 , the script fails to save rollback version if ``config`` folder doesn't exist. The current PR moves folder creation from mcus.sh to utils.sh, the check is done at startup. 