### PR TITLE
Add config_name feature  + fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This is small bash script to update klipper and mcus (main, rpi, can, pico, ... 
     - [RP2040 based board](#rp2040-based-board)
     - [Mainboard : USB connection](#mainboard--usb-connection)
     - [Toolhead : CANbus (Katapult required)](#toolhead--canbus-katapult-required)
+    - [Toolchanger : USB connection](#toolchanger--usb-connection)
 - [About backup](#about-backup)
 - [Questions & Answers](#qa)
 - [TODO](#todo)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 ![UKAM_Banner](./images/banner.png)
 # **UKAM : Update Klipper And Mcus** all-at-once.
 
+> [!WARNING]
+> ### Do not update mcu firmwares with every commit!
+> Modern MCUs have limited write cycles (>100K cycles for an EEPROM, about 10K cycles for a STM32 chip). Updating the firmware with each release could shorten the life of your MCU.
+> 
+> ### How often should I use UKAM? 
+> Every time Klipper mentions to update an MCU at startup, no more.
+> ### So why do I need UKAM ?
+> It will make your life easier when Klipper asks you to update your MCUs.
+
 This is small bash script to update klipper and mcus (main, rpi, can, pico, ... ) and **keep trace of config file for the next update !**
 
-> [!IMPORTANT]
+> [!NOTE]
 > The version 0.0.5 of the script introduces major changes:
 > - `ukam.sh` replaces `update_klipper.sh`
 > - `ukam.sh` need also `./scripts` folder in order to work properly

--- a/scripts/mcus.sh
+++ b/scripts/mcus.sh
@@ -128,12 +128,16 @@ function update_mcus() {
     # Open menuconfig if needed
     if $TMP_MENUCONFIG; then
       make menuconfig $config_file_str
+      # Check a menuconfig file is saved
+      if [ ! -f $config_path ]; 
+        error_exit "No config file, No update." \
+         "Next time, save the menuconfig changes. Bye !"
+      fi
     fi
     # Check if forged ID is present in config file for shared config
     if $SHARED_CONFIG; then
       while grep -q -E "# CONFIG_USB_SERIAL_NUMBER_CHIPID|"\
 "# CONFIG_CAN_UUID_USE_CHIPID" $config_path; do
-
         echo -e "${RED}Forged Serial/CanBus ID is incompatible with " \
           "config_name option.${DEFAULT}"
         if prompt "Change menuconfig now ?"; then

--- a/scripts/mcus.sh
+++ b/scripts/mcus.sh
@@ -126,14 +126,8 @@ function update_mcus() {
     # Clean the previous build and configure for the selected MCU
     make clean $config_file_str
     # Open menuconfig if needed
-    if $TMP_MENUCONFIG; then
-      make menuconfig $config_file_str
-      # Check a menuconfig file is saved
-      if [[ ! -f $config_path ]]; then
-        error_exit "No config file, No update." \
-         "Next time, save the menuconfig changes. Bye !"
-      fi
-    fi
+    $TMP_MENUCONFIG && make menuconfig $config_file_str
+
     # Check if forged ID is present in config file for shared config
     if $SHARED_CONFIG; then
       while grep -q -E "# CONFIG_USB_SERIAL_NUMBER_CHIPID|"\
@@ -142,7 +136,6 @@ function update_mcus() {
           "config_name option.${DEFAULT}"
         if prompt "Change menuconfig now ?"; then
           make menuconfig $config_file_str
-          while [[ ! -f $config_path ]]; do sleep 1; done
         else
           error_exit "Serial ID must not be forged with config_name option"
         fi

--- a/scripts/mcus.sh
+++ b/scripts/mcus.sh
@@ -112,7 +112,7 @@ function update_mcus() {
     fi
     config_path="$ukam_config/config/config.$target"
     config_file_str="KCONFIG_CONFIG=$config_path"
-    if [[ ! -f "$config_path" ]]; then
+    if [[ ! -f $config_path ]]; then
       $QUIET && error_exit "${1^} No config file for $mcu_str in " \
         "$ukam_config/config \nDon't use quiet mode on first " \
         "firmware update!"
@@ -129,7 +129,7 @@ function update_mcus() {
     if $TMP_MENUCONFIG; then
       make menuconfig $config_file_str
       # Check a menuconfig file is saved
-      if [ ! -f $config_path ]; 
+      if [[ ! -f $config_path ]]; then
         error_exit "No config file, No update." \
          "Next time, save the menuconfig changes. Bye !"
       fi
@@ -142,9 +142,9 @@ function update_mcus() {
           "config_name option.${DEFAULT}"
         if prompt "Change menuconfig now ?"; then
           make menuconfig $config_file_str
-          while [ ! -f $config_path ]; do sleep 1; done
+          while [[ ! -f $config_path ]]; do sleep 1; done
         else
-          error_exit "Serial id must not be forged while config file is shared"
+          error_exit "Serial ID must not be forged with config_name option"
         fi
       done
     fi

--- a/scripts/mcus.sh
+++ b/scripts/mcus.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-# Define an associative arrays "flash_actions", "mcu_info"
+# Define an associative arrays "flash_actions", "mcu_info", "mcu_version", "config_name"
 declare -A flash_actions
 declare -A mcu_info
 declare -A mcu_version
+declare -A config_name
 # Define an indexed array "mcu_order" to store the order of MCUs in mcus.ini
 mcu_order=()
 
@@ -42,6 +43,8 @@ function load_mcus_config() {
         fi
       elif [[ $key == klipper_section ]]; then
         mcu_info["$section"]=$(echo $value)
+      elif [[ $key == config_name ]]; then
+        config_name["$section"]=$(echo $value)
       fi
     done <<<"$file_content"
 
@@ -70,6 +73,9 @@ function load_mcus_config() {
 function update_mcus() {
   # Loop over the keys (MCUs) in the flash_actions array
   for mcu in "${mcu_order[@]}"; do
+    # Initiate variables for current mcu
+    TMP_MENUCONFIG=$MENUCONFIG
+    SHARED_CONFIG=false
     def=y
     if [ -n "${mcu_version["$mcu"]}" ]; then
       mcu_str="$mcu [${mcu_info["$mcu"]}]"
@@ -98,10 +104,12 @@ function update_mcus() {
       continue
     fi
 
-    # Initiate menuconfig check for current mcu
-    TMP_MENUCONFIG=$MENUCONFIG
     # Set config_file in the scripts directory
     target=$(echo $mcu | tr ' ' '_')
+    if [ -n "${config_name["$mcu"]}" ]; then
+      target=$(echo ${config_name["$mcu"]} | tr ' ' '_')
+      SHARED_CONFIG=true
+    fi
     config_path="$ukam_config/config/config.$target"
     config_file_str="KCONFIG_CONFIG=$config_path"
     if [[ ! -f "$config_path" ]]; then
@@ -120,6 +128,21 @@ function update_mcus() {
     # Open menuconfig if needed
     if $TMP_MENUCONFIG; then
       make menuconfig $config_file_str
+    fi
+    # Check if forged ID is present in config file for shared config
+    if $SHARED_CONFIG; then
+      while grep -q -E "# CONFIG_USB_SERIAL_NUMBER_CHIPID|"\
+"# CONFIG_CAN_UUID_USE_CHIPID" $config_path; do
+
+        echo -e "${RED}Forged Serial/CanBus ID is incompatible with " \
+          "config_name option.${DEFAULT}"
+        if prompt "Change menuconfig now ?"; then
+          make menuconfig $config_file_str
+          while [ ! -f $config_path ]; do sleep 1; done
+        else
+          error_exit "Serial id must not be forged while config file is shared"
+        fi
+      done
     fi
 
     # Check CPU thread number (added by @roguyt to build faster)

--- a/scripts/moonraker.sh
+++ b/scripts/moonraker.sh
@@ -5,60 +5,74 @@ function moonraker_query() {
   local object=$(echo "$1" | sed 's/ /%20/g')
   moonraker_object=http://127.0.0.1:7125/
   eval "$key=\$( curl -s \"$moonraker_object$object\" )"
-  if [[ ! $(echo ${!key} | grep -o '"result":') == '"result":' ]]; then
-    return 1
-  fi
+  [[ ! $(echo ${!key} | grep -o '"result":') == '"result":' ]] && return 1
+  return 0
 }
 
 function parse_json() {
   local value=$(echo "$json" | grep -o "\"$1\": \"[^\"]*" | cut -d'"' -f4)
   # Use eval to assign the value to the variable name passed as $3
+  [[ -z "$value" ]] && return 1
   eval "$2=\"$value\""
+  return 0
 }
 
 function list_mcus() {
   local -n result=$1 # Use nameref for indirect reference
   # Use mapfile to read the output of grep and sed directly into an array
   mapfile -t result < <(echo "$json" | grep -oP '"mcu[^"]*' | sed 's/"//g')
+
+  [[ ${#result[@]} -eq 0 ]] && return 1
+  return 0
 }
 
 function get_mcus_version() {
-  if moonraker_query printer/info json; then
-
-    parse_json state printer_state
-    case $printer_state in
-    ready)
-      moonraker_query printer/objects/query?print_stats json
-      parse_json state klipper_state
-      case $klipper_state in
-      printing | paused)
-        error_exit "Printer is not ready (${klipper_state}) ! YOU " \
-          "MUST NOT UPDATE MCUS WHILE PRINTING !"
-        ;;
-      *)
-        moonraker_query printer/objects/list json
-        list_mcus mcus
-        for mcu in "${mcus[@]}"; do
-          moonraker_query "printer/objects/query?$mcu" json
-          parse_json mcu_version tmp
-          for cmcu in "${mcu_order[@]}"; do
-            if [[ $mcu == ${mcu_info["$cmcu"]} ]]; then
-              mcu_version["$cmcu"]=$tmp
-            fi
-          done
-        done
-        return 0
-        ;;
-      esac
-      ;;
-    startup | shutdown | error)
-      echo -e "${RED}Klippy state: ${printer_state}.${DEFAULT} Unable " \
-        "to collect Klipper infos on mcus"
-      return 0
-      ;;
-    esac
-  fi
-  echo -e "${RED}Failed to query Moonraker. Unable to collect Klipper " \
+  # Check if printer info is available
+  if ! moonraker_query printer/info json; then
+    echo -e "${RED}Failed to query Moonraker. Unable to collect Klipper " \
     "infos on mcus${DEFAULT}"
+    return 0
+  fi
+
+  parse_json state printer_state
+  # Abort if printer is startup 
+  if [[ $printer_state == "startup" ]]; then
+    echo -e "${RED}Klippy state: startup.${DEFAULT} Unable to " \
+    "collect mcus firmware version"
+    return 0
+  fi
+
+  # Check printer state
+  moonraker_query printer/objects/query?print_stats json
+  parse_json state klipper_state
+  if [[ $klipper_state =~ ^(printing|paused)$ ]]; then
+    error_exit "Printer is not ready (${klipper_state}) ! YOU MUST NOT " \
+    "UPDATE MCUS PRINTING !"
+    return 0
+  fi
+
+  # Get MCU list and versions
+  moonraker_query printer/objects/list json
+  if ! list_mcus mcus; then
+    echo -e "${RED}Klippy state: ${printer_state}.${DEFAULT} Unable " \
+                "to list mcus"
+    return 0
+  fi
+
+  for mcu in "${mcus[@]}"; do
+    moonraker_query "printer/objects/query?$mcu" json
+    if ! parse_json mcu_version tmp; then
+      echo -e "${RED}Klippy state: ${printer_state}.${DEFAULT} Unable to " \
+      "collect ${mcu} firmware version"
+      return 0
+    fi
+
+    for cmcu in "${mcu_order[@]}"; do
+      if [[ $mcu == ${mcu_info["$cmcu"]} ]]; then
+        mcu_version["$cmcu"]=$tmp
+      fi
+    done
+  done
+
   return 0
 }


### PR DESCRIPTION
The current PR adds `config_name` setting to share menuconfig between boards  as requested #10
It improves the way to check mcu version via moonraker.
