### PR TITLE
Fix issue #13 : false duplicate section

### DIFF
--- a/scripts/mcus.sh
+++ b/scripts/mcus.sh
@@ -20,9 +20,8 @@ function load_mcus_config() {
         section=${section%]}
 
         # Check if section already exists
-        if [[ " ${mcu_order[@]} " =~ " ${section} " ]]; then
+        IFS="|"; [[ "|${mcu_order[*]}|" =~ "|$section|" ]] &&
           error_exit "Duplicate section [$section] found in $filename"
-        fi
 
         # Store the order of MCUs in mcu_order array
         mcu_order+=("$section")


### PR DESCRIPTION
If the section name contains spaces, this can lead to incorrect detection of duplicates.
This PR uses pipe character to expand mcu array instead of space.

partly fix issue #13   