### PR TITLE
Fix QUIET and exit error message

### DIFF
--- a/scripts/mcus.sh
+++ b/scripts/mcus.sh
@@ -30,7 +30,7 @@ function load_mcus_config() {
         $key == action_command ]]; then
 
         # Make command quiet, except for stderr, when needed
-        if [[ $key == quiet_command ]] && $QUIET; then
+        if [[ $key == quiet_command ]] || $QUIET; then
           value="$value >/dev/null"
         fi
 
@@ -162,13 +162,9 @@ function update_mcus() {
           # Add KCONFIG_CONFIG=config/$mcu after "make flash"
           command="${command/make\ flash/make\ flash\ $config_file_str}"
         fi
-        if [[ "$command" =~ [[:space:]]*enter_bootloader ]]; then
-          # Execute enter_bootloader directly
-          $command
-        else
-          echo "Command: $command"
-          eval "$command"
-        fi
+        [[ ! "$command" =~ ">/dev/null" ]] && ! $QUIET &&
+         echo "Command: $command"
+        eval "$command"
       done
     fi
   done

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -53,6 +53,10 @@ function error_exit() {
   exit 1
 }
 
+# Handle unexpected error() {
+function handle_error() {
+  IFS=" "; error_exit Unexpected error $*
+}
 # Function to enter bootloader mode
 # Usage  : enter_bootloader -t [type:usb|serial|can] -d [serial]
 #                           -u [canbus_uuid] -b [baudrate]

--- a/ukam.sh
+++ b/ukam.sh
@@ -16,7 +16,8 @@
 # this program. If not, see http://www.gnu.org/licenses/.
 
 # Exit on error
-set -e
+set -e -E
+trap 'handle_error $?' ERR
 # Get Current script fullpath
 ukam_path=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # Config_path


### PR DESCRIPTION
Fix :
- quiet_command still appears 
- QUIET shows output
- enter_bootloader is incorrectly evaluated on some system