### PR TITLE
fix "external script requires klipper running"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ UKAM is not so small bash script to update or rollback klipper/kalico and mcus (
 ## Table of Contents 
 - [What UKAM does ?](#what-ukam-does-)
 - [Installation](#installation)
-  - [Method 1 : git clone (recommended)](#method-1--git-clone)
-  - [Method 2 : manual copy](#method-2--manual-copy)
 - [Update UKAM with Moonraker](#update-ukam-with-moonraker)
 - [Usage](#usage)
   - [Options](#options)
@@ -104,28 +102,17 @@ service klipper start
 
 ## Installation
 
-### Method 1 : Git clone (recommended)
 ```
 cd ~
 git clone https://github.com/fbeauKmi/update_klipper_and_mcus.git ukam
 ```
 
-Copy and edit `mcus.ini` from `examples` folder to `~/printer_data/config/ukam`
+Run Ukam with the following commands to create folders
 
-
-### Method 2 : Manual copy
-Copy `ukam.sh` and  `/scripts/*.sh` in a folder of your pi, `~/ukam/` sounds as a good choice. Let's call this folder `~/<script_folder>` in this Readme.
-Copy and edit `mcus.ini` from `examples` folder to `~/printer_data/config/ukam`
-
-Ensure to make `ukam.sh` executable : 
 ```
-chmod +x ~/<script_folder>/ukam.sh
-chmod +x ~/<script_folder>/scripts/*.sh
+cd ukam
+./ukam.sh -c
 ```
-
-> [!CAUTION]
-> This method does not track update of the script 
-
 
 ## Update UKAM with Moonraker
 
@@ -352,16 +339,26 @@ _source : [issue #10](https://github.com/fbeauKmi/update_klipper_and_mcus/issues
 
 #### Non Klipper firmwares
 ```elixir
-#Cartographer
+#Beacon3d
+[beacon]
+is_klipper_fw: false
+quiet_command: sudo systemctl stop klipper
+action_command: git -C ~/beacon_klipper pull
+action_command: ~/beacon_klipper/update_firmware.py update all
+
+# Cartographer
+# Note: place the Cartographer section first, as it requires Klipper to be running.
 [cartographer]
 klipper_section: mcu scanner
 is_klipper_fw: false
-action_command: ~/cartographer-klipper/scripts/firmware.py -d <canbus_uuid> -f CAN
+action_command: git -C ~/cartographer_firmware pull
+action_command: ~/cartographer_firmware/fw_update.sh
 
 # Crampon ADXL  
 [crampon]
 klipper_section: mcu crampon
 is_klipper_fw: false
+action_command: git -C ~/crampon_anchor pull
 action_command: ~/crampon_anchor/update.sh
 ```
 _source : [issue #12](https://github.com/fbeauKmi/update_klipper_and_mcus/issues/12)_

--- a/examples/mcus.ini
+++ b/examples/mcus.ini
@@ -1,33 +1,39 @@
 # This file stores the flash_commands for each mcus
 # Previous version KCONFIG_CONFIG was needed now it is automaticly added when make flash is called
-# version : 0.1
+# version : 0.2
 # tested/supported flash methods :
 #  - make flash
 #  - sdcard_flash
 #  - flashtool.py
 #  - mount/cp/umount (for rp2040)
- 
+#  - external scripts ...
+
+#[cartographer]
+#klipper_section: mcu scanner
+#is_klipper_fw: false
+#action_command: git -C ~/cartographer_firmware pull
+#action_command: ~/cartographer_firmware/fw_update.sh
+
 #[rpi]
 #klipper_section: mcu rpi
 #action_command: make flash
 
-#[octopus]
+#[Octopus]
 #klipper_section: mcu
-#action_command: ~/klipper/scripts/flash-sdcard.sh /dev/ttyAMA0 btt-octopus-f446-v1
-
-#[mcu]
+#action_command: make flash /dev/serial/by-id/usb-Klipper_stm32f446xx_<BOARD_ID>-if00
 #quiet_command: enter_bootloader -u <YOUR_CANBUS_UUID>
 #action_command: ~/klippy-env/bin/python3 ~/katapult/scripts/flashtool.py -d /dev/serial/by-id/usb-katapult_stm32f446xx_<BOARD_ID>-if00
+
+#[EBB36]
+#klipper_section: mcu toolhead
+#action_command: ~/klippy-env/bin/python3 ~/katapult/scripts/flashtool.py -i can0 -u 2fc4afec81e3  
 
 #[nevermore]
 #klipper_section: mcu nevermore
 #action_command: make flash FLASH_DEVICE=/dev/serial/by-id/usb-Klipper_rp2040_<your_id_here>-if00
 
-#[pico]
-#action_command: sudo mount /dev/sda1 /mnt 
-#action_command: sudo cp out/klipper.uf2 /mnt
-#quiet_command: sudo umount /mnt
-
-#[sht36]
-#klipper_section: mcu toolhead
-#action_command: ~/klippy-env/bin/python3 ~/katapult/scripts/flashtool.py -i can0 -u 2fc4afec81e3  
+#[beacon]
+#is_klipper_fw: false
+#quiet_command: sudo systemctl stop klipper
+#action_command: git -C ~/beacon_klipper pull
+#action_command: ~/beacon_klipper/update_firmware.py update all

--- a/scripts/mcus.sh
+++ b/scripts/mcus.sh
@@ -176,11 +176,12 @@ function update_mcus() {
     if ! prompt "Update firmware of ${WHITE}$mcu_str${MAGENTA} ?" $def; then
       continue
     fi
-    # Stop klipper before build firmware
-    klipperservice stop
+
 
     # build firmware for Klipper
     if $BUILD_FIRMWARE; then
+      # Stop Klipper before building firmware; some non-Klipper firmware scripts require Klipper running
+      klipperservice stop
       # Change to the Klipper directory
       cd ~/klipper
       # Clean the previous build and configure for the selected MCU


### PR DESCRIPTION
Cartographer script require Klipper to run to detect Cartographer settings. 

To ensure compatibility, Klipper is stopped only if a klipper firmware is built.

Known issue : klipper fails during flash process, a firmware_restart must be done after flash 